### PR TITLE
feat: insert options and formatting

### DIFF
--- a/tutorials/src/bin/delete.rs
+++ b/tutorials/src/bin/delete.rs
@@ -1,30 +1,29 @@
 use grovedb::GroveDb;
 
 fn main() {
+    // Specify a path and open GroveDB at the path as db
+    let path = String::from("../storage");
+    let db = GroveDb::open(path).unwrap();
 
-   // Specify a path and open GroveDB at the path as db
-   let path = String::from("../storage");
-   let db = GroveDb::open(path).unwrap();
+    // Check the key-values are there
+    let key1 = b"hello";
+    let key2 = b"grovedb";
+    let result1 = db.get([], key1, None).unwrap();
+    let result2 = db.get([], key2, None).unwrap();
+    println!("Before deleting, we have key1: {:?}", result1);
+    println!("Before deleting, we have key2: {:?}", result2);
 
-   // Check the key-values are there
-   let key1 = b"hello";
-   let key2 = b"grovedb";
-   let result1 = db.get([], key1, None).unwrap();
-   let result2 = db.get([], key2, None).unwrap();
-   println!("Before deleting, we have key1: {:?}", result1);
-   println!("Before deleting, we have key2: {:?}", result2);
+    // Delete the values
+    db.delete([], key1, None, None)
+        .unwrap()
+        .expect("successfully deleted key1");
+    db.delete([], key2, None, None)
+        .unwrap()
+        .expect("successfully deleted key2");
 
-   // Delete the values
-   db.delete([], key1, None, None)
-      .unwrap()
-      .expect("successfully deleted key1");
-   db.delete([], key2, None, None)
-      .unwrap()
-      .expect("successfully deleted key2");
-
-   // Check the key-values again
-   let result3 = db.get([], key1, None).unwrap();
-   let result4 = db.get([], key2, None).unwrap();
-   println!("After deleting, we have key1: {:?}", result3);
-   println!("After deleting, we have key2: {:?}", result4);
+    // Check the key-values again
+    let result3 = db.get([], key1, None).unwrap();
+    let result4 = db.get([], key2, None).unwrap();
+    println!("After deleting, we have key1: {:?}", result3);
+    println!("After deleting, we have key2: {:?}", result4);
 }

--- a/tutorials/src/bin/insert.rs
+++ b/tutorials/src/bin/insert.rs
@@ -1,41 +1,40 @@
-use grovedb::GroveDb;
 use grovedb::Element;
+use grovedb::GroveDb;
 
 fn main() {
+    // Specify a path and open GroveDB at the path as db
+    let path = String::from("../storage");
+    let db = GroveDb::open(path).unwrap();
 
-   // Specify a path and open GroveDB at the path as db
-   let path = String::from("../storage");
-   let db = GroveDb::open(path).unwrap();
+    // Define key-values for insertion
+    let key1 = b"hello";
+    let val1 = b"world";
+    let key2 = b"grovedb";
+    let val2 = b"rocks";
 
-   // Define key-values for insertion
-   let key1 = b"hello";
-   let val1 = b"world";
-   let key2 = b"grovedb";
-   let val2 = b"rocks";
+    // Insert key-value 1 into the root tree
+    db.insert([], key1, Element::Item(val1.to_vec(), None), None, None)
+        .unwrap()
+        .expect("successful key1 insert");
 
-   // Insert key-value 1 into the root tree
-   db.insert([], key1, Element::Item(val1.to_vec(), None), None, None)
-       .unwrap()
-       .expect("successful key1 insert");
+    // Insert key-value 2 into the root tree
+    db.insert([], key2, Element::Item(val2.to_vec(), None), None, None)
+        .unwrap()
+        .expect("successful key2 insert");
 
-   // Insert key-value 2 into the root tree
-   db.insert([], key2, Element::Item(val2.to_vec(), None), None, None)
-       .unwrap()
-       .expect("successful key2 insert");
+    // At this point the Items are fully inserted into the database.
+    // No other steps are required.
 
-   // At this point the Items are fully inserted into the database.
-   // No other steps are required.
+    // To show that the Items are there, we will use the get()
+    // function to get them from the RocksDB backing store.
 
-   // To show that the Items are there, we will use the get()
-   // function to get them from the RocksDB backing store.
+    // Get value 1
+    let result1 = db.get([], key1, None).unwrap();
 
-   // Get value 1
-   let result1 = db.get([], key1, None).unwrap();
+    // Get value 2
+    let result2 = db.get([], key2, None).unwrap();
 
-   // Get value 2
-   let result2 = db.get([], key2, None).unwrap();
-
-   // Print the values to terminal
-   println!("{:?}", result1);
-   println!("{:?}", result2);
+    // Print the values to terminal
+    println!("{:?}", result1);
+    println!("{:?}", result2);
 }

--- a/tutorials/src/bin/open.rs
+++ b/tutorials/src/bin/open.rs
@@ -1,12 +1,11 @@
 use grovedb::GroveDb;
 
 fn main() {
+    // Specify the path where you want to set up the GroveDB instance
+    let path = String::from("../storage");
 
-   // Specify the path where you want to set up the GroveDB instance
-   let path = String::from("../storage");
-  
-   // Open a new GroveDB at the path
-   GroveDb::open(&path).unwrap();
+    // Open a new GroveDB at the path
+    GroveDb::open(&path).unwrap();
 
-   println!("Opened {:?}", path);
+    println!("Opened {:?}", path);
 }

--- a/tutorials/src/bin/proofs.rs
+++ b/tutorials/src/bin/proofs.rs
@@ -1,11 +1,10 @@
 use grovedb::GroveDb;
-use grovedb::{ Query, PathQuery };
+use grovedb::{PathQuery, Query};
 
 const KEY1: &[u8] = b"key1";
 const KEY2: &[u8] = b"key2";
 
 fn main() {
-
     // Specify the path to the previously created GroveDB instance
     let path = String::from("../storage");
     // Open GroveDB as db
@@ -34,5 +33,7 @@ fn main() {
     println!("Does the hash generated from the query proof match the GroveDB root hash?");
     if hash == db.root_hash(None).unwrap().unwrap() {
         println!("Yes");
-    } else { println!("No"); };
+    } else {
+        println!("No");
+    };
 }

--- a/tutorials/src/bin/query-complex.rs
+++ b/tutorials/src/bin/query-complex.rs
@@ -1,18 +1,21 @@
-use grovedb::GroveDb;
-use grovedb::Element;
 use grovedb::operations::insert::InsertOptions;
-use grovedb::{ Query, PathQuery, QueryItem, SizedQuery };
+use grovedb::Element;
+use grovedb::GroveDb;
+use grovedb::{PathQuery, Query, QueryItem, SizedQuery};
 use rand::Rng;
 
 const KEY1: &[u8] = b"key1";
 const KEY2: &[u8] = b"key2";
-const INSERT_OPTIONS: Option<InsertOptions> = Some(InsertOptions { validate_insertion_does_not_override: false, validate_insertion_does_not_override_tree: false, base_root_storage_is_free: true });
+const INSERT_OPTIONS: Option<InsertOptions> = Some(InsertOptions {
+    validate_insertion_does_not_override: false,
+    validate_insertion_does_not_override_tree: false,
+    base_root_storage_is_free: true,
+});
 
 fn main() {
-   
     // Specify the path where the GroveDB instance exists.
     let path = String::from("../storage");
-    
+
     // Open GroveDB at the path.
     let db = GroveDb::open(path).unwrap();
 
@@ -30,25 +33,21 @@ fn main() {
     // Insert query items into the queries.
     // Query 20-30 at path.
     query.insert_range(20_u8.to_be_bytes().to_vec()..31_u8.to_be_bytes().to_vec());
-    // If any 20-30 are subtrees and meet the subquery condition, 
+    // If any 20-30 are subtrees and meet the subquery condition,
     // follow the path and query 60, 70 from there.
-    subquery.insert_keys(vec![vec![60],vec![70]]);
+    subquery.insert_keys(vec![vec![60], vec![70]]);
     // If either 60, 70 are subtrees and meet the subquery condition,
     // follow the path and query 90-94 from there.
     subquery2.insert_range(90_u8.to_be_bytes().to_vec()..95_u8.to_be_bytes().to_vec());
 
     // Add subquery branches.
     // If 60 is a subtree, run subquery2 on it. No path.
-    subquery.add_conditional_subquery(
-        QueryItem::Key(vec![60]),
-        None,
-        Some(subquery2)
-    );
+    subquery.add_conditional_subquery(QueryItem::Key(vec![60]), None, Some(subquery2));
     // If anything up to and including 25 is a subtree, run subquery on it. No path.
     query.add_conditional_subquery(
         QueryItem::RangeToInclusive(std::ops::RangeToInclusive { end: vec![25] }),
         None,
-        Some(subquery)
+        Some(subquery),
     );
 
     // Put the query into a sized query. Limit the result set to 10,
@@ -66,11 +65,9 @@ fn main() {
 
     // Print result items to terminal.
     println!("{:?}", elements);
-
 }
 
 fn populate(db: &GroveDb) {
-
     // Put an empty subtree into the root tree nodes at KEY1.
     // Call this SUBTREE1.
     db.insert([], KEY1, Element::empty_tree(), INSERT_OPTIONS, None)
@@ -86,9 +83,15 @@ fn populate(db: &GroveDb) {
     // Populate SUBTREE2 with values 0 through 49 under keys 0 through 49.
     for i in 0u8..50 {
         let i_vec = (i as u8).to_be_bytes().to_vec();
-        db.insert([KEY1, KEY2], &i_vec, Element::new_item(i_vec.clone()), INSERT_OPTIONS, None)
-            .unwrap()
-            .expect("successfully inserted values in SUBTREE2");
+        db.insert(
+            [KEY1, KEY2],
+            &i_vec,
+            Element::new_item(i_vec.clone()),
+            INSERT_OPTIONS,
+            None,
+        )
+        .unwrap()
+        .expect("successfully inserted values in SUBTREE2");
     }
 
     // Set random_numbers
@@ -98,30 +101,53 @@ fn populate(db: &GroveDb) {
 
     // Overwrite key rn1 with a subtree
     // Call this SUBTREE3
-    db.insert([KEY1, KEY2], &rn1, Element::empty_tree(), INSERT_OPTIONS, None)
-        .unwrap()
-        .expect("successful SUBTREE3 insert");
+    db.insert(
+        [KEY1, KEY2],
+        &rn1,
+        Element::empty_tree(),
+        INSERT_OPTIONS,
+        None,
+    )
+    .unwrap()
+    .expect("successful SUBTREE3 insert");
 
     // Populate SUBTREE3 with values 50 through 74 under keys 50 through 74
     for i in 50u8..75 {
         let i_vec = (i as u8).to_be_bytes().to_vec();
-        db.insert([KEY1, KEY2, rn1], &i_vec, Element::new_item(i_vec.clone()), INSERT_OPTIONS, None)
-            .unwrap()
-            .expect("successfully inserted values in SUBTREE3");
+        db.insert(
+            [KEY1, KEY2, rn1],
+            &i_vec,
+            Element::new_item(i_vec.clone()),
+            INSERT_OPTIONS,
+            None,
+        )
+        .unwrap()
+        .expect("successfully inserted values in SUBTREE3");
     }
 
     // Overwrite key rn2 with a subtree
     // Call this SUBTREE4
-    db.insert([KEY1, KEY2, rn1], &rn2, Element::empty_tree(), INSERT_OPTIONS, None)
-        .unwrap()
-        .expect("successful SUBTREE4 insert");
+    db.insert(
+        [KEY1, KEY2, rn1],
+        &rn2,
+        Element::empty_tree(),
+        INSERT_OPTIONS,
+        None,
+    )
+    .unwrap()
+    .expect("successful SUBTREE4 insert");
 
     // Populate SUBTREE4 with values 75 through 99 under keys 75 through 99
     for i in 75u8..99 {
         let i_vec = (i as u8).to_be_bytes().to_vec();
-        db.insert([KEY1, KEY2, rn1, rn2], &i_vec, Element::new_item(i_vec.clone()), INSERT_OPTIONS, None)
-            .unwrap()
-            .expect("successfully inserted values in SUBTREE4");
+        db.insert(
+            [KEY1, KEY2, rn1, rn2],
+            &i_vec,
+            Element::new_item(i_vec.clone()),
+            INSERT_OPTIONS,
+            None,
+        )
+        .unwrap()
+        .expect("successfully inserted values in SUBTREE4");
     }
-
 }

--- a/tutorials/src/bin/query-complex.rs
+++ b/tutorials/src/bin/query-complex.rs
@@ -1,10 +1,12 @@
 use grovedb::GroveDb;
 use grovedb::Element;
+use grovedb::operations::insert::InsertOptions;
 use grovedb::{ Query, PathQuery, QueryItem, SizedQuery };
 use rand::Rng;
 
 const KEY1: &[u8] = b"key1";
 const KEY2: &[u8] = b"key2";
+const INSERT_OPTIONS: Option<InsertOptions> = Some(InsertOptions { validate_insertion_does_not_override: false, validate_insertion_does_not_override_tree: false, base_root_storage_is_free: true });
 
 fn main() {
    
@@ -71,20 +73,20 @@ fn populate(db: &GroveDb) {
 
     // Put an empty subtree into the root tree nodes at KEY1.
     // Call this SUBTREE1.
-    db.insert([], KEY1, Element::empty_tree(), None, None)
+    db.insert([], KEY1, Element::empty_tree(), INSERT_OPTIONS, None)
         .unwrap()
         .expect("successful SUBTREE1 insert");
 
     // Put an empty subtree into subtree1 at KEY2.
     // Call this SUBTREE2.
-    db.insert([KEY1], KEY2, Element::empty_tree(), None, None)
+    db.insert([KEY1], KEY2, Element::empty_tree(), INSERT_OPTIONS, None)
         .unwrap()
         .expect("successful SUBTREE2 insert");
 
     // Populate SUBTREE2 with values 0 through 49 under keys 0 through 49.
     for i in 0u8..50 {
         let i_vec = (i as u8).to_be_bytes().to_vec();
-        db.insert([KEY1, KEY2], &i_vec, Element::new_item(i_vec.clone()), None, None)
+        db.insert([KEY1, KEY2], &i_vec, Element::new_item(i_vec.clone()), INSERT_OPTIONS, None)
             .unwrap()
             .expect("successfully inserted values in SUBTREE2");
     }
@@ -96,28 +98,28 @@ fn populate(db: &GroveDb) {
 
     // Overwrite key rn1 with a subtree
     // Call this SUBTREE3
-    db.insert([KEY1, KEY2], &rn1, Element::empty_tree(), None, None)
+    db.insert([KEY1, KEY2], &rn1, Element::empty_tree(), INSERT_OPTIONS, None)
         .unwrap()
         .expect("successful SUBTREE3 insert");
 
     // Populate SUBTREE3 with values 50 through 74 under keys 50 through 74
     for i in 50u8..75 {
         let i_vec = (i as u8).to_be_bytes().to_vec();
-        db.insert([KEY1, KEY2, rn1], &i_vec, Element::new_item(i_vec.clone()), None, None)
+        db.insert([KEY1, KEY2, rn1], &i_vec, Element::new_item(i_vec.clone()), INSERT_OPTIONS, None)
             .unwrap()
             .expect("successfully inserted values in SUBTREE3");
     }
 
     // Overwrite key rn2 with a subtree
     // Call this SUBTREE4
-    db.insert([KEY1, KEY2, rn1], &rn2, Element::empty_tree(), None, None)
+    db.insert([KEY1, KEY2, rn1], &rn2, Element::empty_tree(), INSERT_OPTIONS, None)
         .unwrap()
         .expect("successful SUBTREE4 insert");
 
     // Populate SUBTREE4 with values 75 through 99 under keys 75 through 99
     for i in 75u8..99 {
         let i_vec = (i as u8).to_be_bytes().to_vec();
-        db.insert([KEY1, KEY2, rn1, rn2], &i_vec, Element::new_item(i_vec.clone()), None, None)
+        db.insert([KEY1, KEY2, rn1, rn2], &i_vec, Element::new_item(i_vec.clone()), INSERT_OPTIONS, None)
             .unwrap()
             .expect("successfully inserted values in SUBTREE4");
     }

--- a/tutorials/src/bin/query-simple.rs
+++ b/tutorials/src/bin/query-simple.rs
@@ -1,9 +1,11 @@
 use grovedb::GroveDb;
 use grovedb::Element;
+use grovedb::operations::insert::InsertOptions;
 use grovedb::{ Query, PathQuery};
 
 const KEY1: &[u8] = b"key1";
 const KEY2: &[u8] = b"key2";
+const INSERT_OPTIONS: Option<InsertOptions> = Some(InsertOptions { validate_insertion_does_not_override: false, validate_insertion_does_not_override_tree: false, base_root_storage_is_free: true });
 
 fn main() {
    
@@ -44,20 +46,20 @@ fn populate(db: &GroveDb) {
 
     // Put an empty subtree into the root tree nodes at KEY1.
     // Call this SUBTREE1.
-    db.insert([], KEY1, Element::empty_tree(), None, None)
+    db.insert([], KEY1, Element::empty_tree(), INSERT_OPTIONS, None)
         .unwrap()
         .expect("successful SUBTREE1 insert");
 
     // Put an empty subtree into subtree1 at KEY2.
     // Call this SUBTREE2.
-    db.insert([KEY1], KEY2, Element::empty_tree(), None, None)
+    db.insert([KEY1], KEY2, Element::empty_tree(), INSERT_OPTIONS, None)
         .unwrap()
         .expect("successful SUBTREE2 insert");
 
     // Populate SUBTREE2 with values 0 through 99 under keys 0 through 99.
     for i in 0u8..100 {
         let i_vec = (i as u8).to_be_bytes().to_vec();
-        db.insert([KEY1, KEY2], &i_vec, Element::new_item(i_vec.clone()), None, None)
+        db.insert([KEY1, KEY2], &i_vec, Element::new_item(i_vec.clone()), INSERT_OPTIONS, None)
             .unwrap()
             .expect("successfully inserted values");
     }

--- a/tutorials/src/bin/query-simple.rs
+++ b/tutorials/src/bin/query-simple.rs
@@ -1,17 +1,20 @@
-use grovedb::GroveDb;
-use grovedb::Element;
 use grovedb::operations::insert::InsertOptions;
-use grovedb::{ Query, PathQuery};
+use grovedb::Element;
+use grovedb::GroveDb;
+use grovedb::{PathQuery, Query};
 
 const KEY1: &[u8] = b"key1";
 const KEY2: &[u8] = b"key2";
-const INSERT_OPTIONS: Option<InsertOptions> = Some(InsertOptions { validate_insertion_does_not_override: false, validate_insertion_does_not_override_tree: false, base_root_storage_is_free: true });
+const INSERT_OPTIONS: Option<InsertOptions> = Some(InsertOptions {
+    validate_insertion_does_not_override: false,
+    validate_insertion_does_not_override_tree: false,
+    base_root_storage_is_free: true,
+});
 
 fn main() {
-   
     // Specify the path where the GroveDB instance exists.
     let path = String::from("../storage");
-    
+
     // Open GroveDB at the path.
     let db = GroveDb::open(path).unwrap();
 
@@ -39,11 +42,9 @@ fn main() {
 
     // Print result items to terminal.
     println!("{:?}", elements);
-
 }
 
 fn populate(db: &GroveDb) {
-
     // Put an empty subtree into the root tree nodes at KEY1.
     // Call this SUBTREE1.
     db.insert([], KEY1, Element::empty_tree(), INSERT_OPTIONS, None)
@@ -59,8 +60,14 @@ fn populate(db: &GroveDb) {
     // Populate SUBTREE2 with values 0 through 99 under keys 0 through 99.
     for i in 0u8..100 {
         let i_vec = (i as u8).to_be_bytes().to_vec();
-        db.insert([KEY1, KEY2], &i_vec, Element::new_item(i_vec.clone()), INSERT_OPTIONS, None)
-            .unwrap()
-            .expect("successfully inserted values");
+        db.insert(
+            [KEY1, KEY2],
+            &i_vec,
+            Element::new_item(i_vec.clone()),
+            INSERT_OPTIONS,
+            None,
+        )
+        .unwrap()
+        .expect("successfully inserted values");
     }
 }

--- a/tutorials/src/main.rs
+++ b/tutorials/src/main.rs
@@ -1,4 +1,4 @@
 fn main() {
-   println!("Run tutorials via `cargo run --bin <tutorial name>`");
-   println!("Valid tutorial names: open, insert, delete, query-simple, proofs");
+    println!("Run tutorials via `cargo run --bin <tutorial name>`");
+    println!("Valid tutorial names: open, insert, delete, query-simple, proofs");
 }


### PR DESCRIPTION
Ran `cargo fmt` to consistently format files. Also added insert options so query tutorials don't fail after first run.