### PR TITLE
feat: add a devcontainer

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,29 @@
+# Development Container
+
+The development container config ([.devcontainer.json](./devcontainer.json)) enables starting a
+pre-configured [GitHub Codespaces](https://github.com/features/codespaces) environment ready to
+build and run the tutorials in this repository.
+
+## Building the tutorials
+
+Note: it currently takes a long time (5+ minutes) to start a new Codespace for this project
+depending on the machine type selected. Only 4+ core machine types are supported due to the
+resources required to build GroveDB.
+
+Once the Codespace has started and finished running rust-analyzer, run the following command
+to build everything required. This may take an additional 10 minutes depending on the
+Codespace machine selected:
+
+```shell
+cargo build
+```
+
+Note: you may need go to the main menu, click `View`, then `Terminal` if the terminal isn't visible.
+
+## Running the tutorials
+
+To run the tutorials, follow the same instructions as found in the main [README file](../README.md). For example:
+
+```shell
+cargo run --bin open
+```

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,11 +23,17 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "rustc --version",
-	"postCreateCommand": "./.devcontainer/postCreateCommands.sh"
+	"postCreateCommand": "./.devcontainer/postCreateCommands.sh",
 
 	// Configure tool-specific properties.
 	// "customizations": {},
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
+
+	"hostRequirements": {
+		"cpus": 4,
+		"memory": "8gb",
+		"storage": "32gb"
+ }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,11 +26,19 @@
 	"postCreateCommand": "./.devcontainer/postCreateCommands.sh",
 
 	// Configure tool-specific properties.
-	// "customizations": {},
+	"customizations": {
+		"codespaces": {
+			"openFiles": [
+				".devcontainer/README.md",
+				"README.md"
+			]
+		}
+	},
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 
+	// The smallest Codespace machine can't build everything required
 	"hostRequirements": {
 		"cpus": 4,
 		"memory": "8gb",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+	"name": "Rust",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/rust:0-1-bullseye",
+	// "features": {}
+
+	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+	// "mounts": [
+	// 	{
+	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
+	// 		"target": "/usr/local/cargo",
+	// 		"type": "volume"
+	// 	}
+	// ]
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "rustc --version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,25 +4,8 @@
 	"name": "Rust",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/rust:0-1-bullseye",
-	// "features": {}
-
-	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
-	// "mounts": [
-	// 	{
-	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
-	// 		"target": "/usr/local/cargo",
-	// 		"type": "volume"
-	// 	}
-	// ]
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "rustc --version",
 	"postCreateCommand": "./.devcontainer/postCreateCommands.sh",
 
 	// Configure tool-specific properties.
@@ -34,9 +17,6 @@
 			]
 		}
 	},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
 
 	// The smallest Codespace machine can't build everything required
 	"hostRequirements": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,6 +23,7 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "rustc --version",
+	"postCreateCommand": "./.devcontainer/postCreateCommands.sh"
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/.devcontainer/postCreateCommands.sh
+++ b/.devcontainer/postCreateCommands.sh
@@ -1,0 +1,11 @@
+#/!bin/sh
+
+# Command to run during postCreateCommand
+# Done in script because when done via object the commands are run in parallel
+#  (which isn't always desirable)
+# https://containers.dev/implementors/spec/#parallel-exec
+# https://containers.dev/implementors/json_reference/#formatting-string-vs-array-properties
+
+# Needed to build
+sudo apt update
+sudo apt install libclang-dev

--- a/.devcontainer/postCreateCommands.sh
+++ b/.devcontainer/postCreateCommands.sh
@@ -8,4 +8,4 @@
 
 # Needed to build
 sudo apt update
-sudo apt install libclang-dev
+sudo apt install -y libclang-dev


### PR DESCRIPTION
Since groveDB must be built this can't run on the default Codespace size. But if someone really didn't want to install Rust, etc. locally they could use this to run the tutorials.